### PR TITLE
Merge common tags and forge tags together using industrial_creations' internal tag system

### DIFF
--- a/data/industrial_creations/recipes/create_mixing/hydrated_tin_dust.json
+++ b/data/industrial_creations/recipes/create_mixing/hydrated_tin_dust.json
@@ -2,7 +2,7 @@
   "type": "create:mixing",
   "ingredients": [
      {
-      "tag": "forge:dusts/tin"
+      "tag": "industrial_creations:dusts/tin"
     },
     {
       "fluid": "minecraft:water",

--- a/data/industrial_creations/recipes/create_mixing/mixed_metal_ingot.json
+++ b/data/industrial_creations/recipes/create_mixing/mixed_metal_ingot.json
@@ -2,13 +2,13 @@
   "type": "create:mixing",
   "ingredients": [
      {
-      "tag": "forge:plates/iron"
+      "tag": "industrial_creations:plates/iron"
     },
     {
-      "tag": "forge:plates/bronze"
+      "tag": "industrial_creations:plates/bronze"
     },
     {
-      "tag": "forge:plates/tin"
+      "tag": "industrial_creations:plates/tin"
     }
   ],
   "results": [

--- a/data/industrial_creations/tags/items/dusts/tin.json
+++ b/data/industrial_creations/tags/items/dusts/tin.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    { "id": "#forge:dusts/tin", "required": false },
+    { "id": "#c:tin_dusts", "required": false },
+    { "id": "#c:dusts/tin", "required": false }
+  ]
+}

--- a/data/industrial_creations/tags/items/plates/bronze.json
+++ b/data/industrial_creations/tags/items/plates/bronze.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    { "id": "#forge:plates/bronze", "required": false },
+    { "id": "#c:bronze_plates", "required": false },
+    { "id": "#c:plates/bronze", "required": false }
+  ]
+}

--- a/data/industrial_creations/tags/items/plates/iron.json
+++ b/data/industrial_creations/tags/items/plates/iron.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    { "id": "#forge:plates/iron", "required": false },
+    { "id": "#c:iron_plates", "required": false },
+    { "id": "#c:plates/iron", "required": false }
+  ]
+}

--- a/data/industrial_creations/tags/items/plates/tin.json
+++ b/data/industrial_creations/tags/items/plates/tin.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    { "id": "#forge:plates/tin", "required": false },
+    { "id": "#c:tin_plates", "required": false },
+    { "id": "#c:plates/tin", "required": false }
+  ]
+}


### PR DESCRIPTION
What can this do:
- This datapack can load properly in Fabric now.

What this effect:
- Use `industrial_creations` as namespace if you're using forge tags in recipes instead of `forge`.
- If you need to use more forge tags, create an `industrial_creations` tag just like what the pr does.